### PR TITLE
chore: sync develop into main after Results API merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ for {
 - `(*Group[T]).Go(fn TaskFunc[T]) error`
 - `(*Group[T]).Close()`
 - `(*Group[T]).Next(ctx context.Context) (Result[T], bool, error)`
+- `(*Group[T]).Stream(ctx context.Context) *Stream[T]`
 - `(*Group[T]).Wait() error`
 - `(*Group[T]).Cancel(err error)`
 
@@ -102,11 +103,27 @@ for {
 - `Next(ctx)` returns one completion in completion order.
 - `Next(ctx)` returns `ok=false, err=nil` only when `Close()` was called and results are fully drained.
 - `Next(ctx)` returns `ok=false, err=context.*` when caller context ends while waiting.
+- `Stream(ctx).C` yields the same completion-order results as repeated `Next(ctx)`.
+- `Stream(ctx).Done` yields one final error and closes (`Result.Err` remains task-level error).
 - `WithFailFast(true)` cancels group context on first task error.
 - `WithFailFast(false)` keeps remaining tasks running and still reports errors via results and `Wait`.
 - `WithPanicToError(true)` (default) converts panic to task error.
 - `WithPanicToError(false)` rethrows panic (debug-first behavior).
 - `Wait()` returns first observed task error, else context cause, else `nil`.
+
+## Stream Usage
+
+```go
+s := g.Stream(context.Background())
+
+for res := range s.C {
+	// res.Err is task-level error
+}
+
+if err := <-s.Done; err != nil {
+	// stream/group final error
+}
+```
 
 ## Testing
 

--- a/doc.go
+++ b/doc.go
@@ -7,6 +7,7 @@
 // Core behavior:
 //   - submit tasks with Go
 //   - consume completions in completion order via Next(ctx)
+//   - consume completions via range-friendly Stream(ctx)
 //   - stop new submissions with Close
 //   - wait for completion with Wait
 //
@@ -14,6 +15,8 @@
 //   - Next(ctx) returns (res, true, nil) for one completed task
 //   - Next(ctx) returns (zero, false, nil) only after Close and full drain
 //   - Next(ctx) returns (zero, false, ctx.Err()) if caller context ends
+//   - Stream(ctx).C yields Result values in completion order
+//   - Stream(ctx).Done yields one final error and then closes
 //   - Wait returns the first observed task error, then context cause, then nil
 //
 // Policy options:

--- a/doc.go
+++ b/doc.go
@@ -7,7 +7,7 @@
 // Core behavior:
 //   - submit tasks with Go
 //   - consume completions in completion order via Next(ctx)
-//   - consume completions via range-friendly Stream(ctx)
+//   - consume completions via range-friendly Results(ctx)
 //   - stop new submissions with Close
 //   - wait for completion with Wait
 //
@@ -15,8 +15,8 @@
 //   - Next(ctx) returns (res, true, nil) for one completed task
 //   - Next(ctx) returns (zero, false, nil) only after Close and full drain
 //   - Next(ctx) returns (zero, false, ctx.Err()) if caller context ends
-//   - Stream(ctx).C yields Result values in completion order
-//   - Stream(ctx).Done yields one final error and then closes
+//   - Results(ctx) yields Result values in completion order
+//   - Results(ctx) does not own group lifecycle (Close/Cancel/Wait)
 //   - Wait returns the first observed task error, then context cause, then nil
 //
 // Policy options:

--- a/example_test.go
+++ b/example_test.go
@@ -4,36 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jaeyoung0509/seoul"
 )
 
-func ExampleGroup_basic() {
-	g := seoul.New[int](context.Background())
-	_ = g.Go(func(context.Context) (int, error) { return 42, nil })
-	g.Close()
-
-	res, ok, err := g.Next(context.Background())
-	fmt.Println(ok, err == nil, res.Value, res.Err == nil)
-
-	_, ok, err = g.Next(context.Background())
-	fmt.Println(ok, err == nil)
-
-	fmt.Println(g.Wait() == nil)
-	// Output:
-	// true true 42 true
-	// false true
-	// true
-}
-
-func ExampleGroup_failFastDisabled() {
-	errBoom := errors.New("boom")
+func ExampleGroup_next() {
+	// 1) Create group.
 	g := seoul.New[int](context.Background(), seoul.WithFailFast(false))
 
+	// 2) Submit tasks.
+	errBoom := errors.New("boom")
 	_ = g.Go(func(context.Context) (int, error) { return 0, errBoom })
-	_ = g.Go(func(context.Context) (int, error) { return 7, nil })
+	_ = g.Go(func(context.Context) (int, error) { return 42, nil })
+
+	// 3) Seal submissions so Next can terminate with ok=false after drain.
 	g.Close()
 
+	// 4) Pull completions manually with Next.
 	var success, fail int
 	for {
 		res, ok, err := g.Next(context.Background())
@@ -45,14 +33,73 @@ func ExampleGroup_failFastDisabled() {
 		}
 		if res.Err != nil {
 			fail++
-		} else {
-			success++
+			continue
 		}
+		success++
 	}
 
+	// 5) Wait reports final group error semantics.
 	fmt.Printf("success=%d fail=%d\n", success, fail)
 	fmt.Println(errors.Is(g.Wait(), errBoom))
 	// Output:
 	// success=1 fail=1
+	// true
+}
+
+func ExampleGroup_stream() {
+	// Stream is a range-friendly adapter over Next.
+	g := seoul.New[int](context.Background(), seoul.WithFailFast(false))
+
+	first := make(chan struct{})
+	second := make(chan struct{})
+	secondDone := make(chan struct{})
+
+	_ = g.Go(func(context.Context) (int, error) {
+		<-first
+		<-secondDone
+		return 1, nil
+	})
+	_ = g.Go(func(context.Context) (int, error) {
+		<-second
+		close(secondDone)
+		return 2, nil
+	})
+	g.Close()
+
+	s := g.Stream(context.Background())
+
+	// Force completion order: second then first.
+	close(first)
+	close(second)
+
+	for res := range s.C {
+		fmt.Println(res.Value, res.Err == nil)
+	}
+
+	// Done carries one final stream/group error.
+	fmt.Println(<-s.Done == nil)
+	// Output:
+	// 2 true
+	// 1 true
+	// true
+}
+
+func ExampleGroup_stream_contextCancel() {
+	g := seoul.New[int](context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	s := g.Stream(ctx)
+
+	count := 0
+	for range s.C {
+		count++
+	}
+
+	fmt.Println(count)
+	fmt.Println(errors.Is(<-s.Done, context.DeadlineExceeded))
+	// Output:
+	// 0
 	// true
 }

--- a/group.go
+++ b/group.go
@@ -217,7 +217,7 @@ func (g *Group[T]) Results(ctx context.Context) <-chan Result[T] {
 		ctx = context.Background()
 	}
 
-	out := make(chan Result[T])
+	out := make(chan Result[T], 1)
 	go func() {
 		defer close(out)
 		for {


### PR DESCRIPTION
## Summary
- sync `develop` into `main` after merging PR #21
- bring latest Results API/doc/test updates to default branch

## Why
- repository default branch is `main`
- keep `main` current with `develop` to avoid drift and issue auto-close confusion

## Notes
- branch-sync only, no additional code changes
